### PR TITLE
refactor(HashTable): mark legacy lib/ classes deprecated, point to PSR-4 equivalents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,22 @@
             "role": "lead"
         }
     ],
-    "time": "2026-05-28",
+    "time": "2026-06-09",
     "repositories": [],
     "require": {
         "php": "^8.1",
-        "horde/exception": "^3 || dev-FRAMEWORK_6_0"
+        "horde/exception": "^3"
     },
     "require-dev": {
-        "horde/argv": "^3 || dev-FRAMEWORK_6_0",
-        "horde/cli": "^3 || dev-FRAMEWORK_6_0"
+        "horde/argv": "^3",
+        "horde/cli": "^3"
     },
     "suggest": {
-        "horde/argv": "^3 || dev-FRAMEWORK_6_0",
-        "horde/cli": "^3 || dev-FRAMEWORK_6_0",
-        "horde/log": "^3 || dev-FRAMEWORK_6_0",
-        "horde/memcache": "^3 || dev-FRAMEWORK_6_0",
-        "horde/vfs": "^3 || dev-FRAMEWORK_6_0",
+        "horde/argv": "^3",
+        "horde/cli": "^3",
+        "horde/log": "^3",
+        "horde/memcache": "^3",
+        "horde/vfs": "^3",
         "predis/predis": "^2 || ^3"
     },
     "autoload": {
@@ -50,10 +50,5 @@
     ],
     "config": {
         "allow-plugins": {}
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-FRAMEWORK_6_0": "2.x-dev"
-        }
     }
 }

--- a/lib/Horde/HashTable/Base.php
+++ b/lib/Horde/HashTable/Base.php
@@ -27,6 +27,12 @@
  * @property-read boolean $persistent  Does hash table provide persistent
  *                                     storage?
  * @property-write string $prefix  Set the hash key prefix.
+ *
+ * @deprecated Use {@see \Horde\HashTable\HashTable} (and the
+ *             {@see \Horde\HashTable\LockableHashTable} /
+ *             {@see \Horde\HashTable\RedisHashTable} extensions). The PSR-4
+ *             interfaces support phpredis as well as Predis and use plain
+ *             prefix+key storage instead of the legacy MD5 hashing.
  */
 abstract class Horde_HashTable_Base implements ArrayAccess, Serializable
 {

--- a/lib/Horde/HashTable/Lock.php
+++ b/lib/Horde/HashTable/Lock.php
@@ -21,6 +21,8 @@
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
+ *
+ * @deprecated Use {@see \Horde\HashTable\LockableHashTable}.
  */
 interface Horde_HashTable_Lock
 {

--- a/lib/Horde/HashTable/Memcache.php
+++ b/lib/Horde/HashTable/Memcache.php
@@ -20,6 +20,8 @@
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
+ *
+ * @deprecated Use {@see \Horde\HashTable\Driver\Memcache}.
  */
 class Horde_HashTable_Memcache extends Horde_HashTable_Base implements Horde_HashTable_Lock
 {

--- a/lib/Horde/HashTable/Memory.php
+++ b/lib/Horde/HashTable/Memory.php
@@ -20,6 +20,8 @@
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
+ *
+ * @deprecated Use {@see \Horde\HashTable\Driver\Memory}.
  */
 class Horde_HashTable_Memory extends Horde_HashTable_Base implements Horde_HashTable_Lock
 {

--- a/lib/Horde/HashTable/Null.php
+++ b/lib/Horde/HashTable/Null.php
@@ -20,6 +20,8 @@
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
+ *
+ * @deprecated Use {@see \Horde\HashTable\Driver\NullDriver}.
  */
 class Horde_HashTable_Null extends Horde_HashTable_Base implements Horde_HashTable_Lock
 {

--- a/lib/Horde/HashTable/Predis.php
+++ b/lib/Horde/HashTable/Predis.php
@@ -22,6 +22,11 @@
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
+ *
+ * @deprecated Use {@see \Horde\HashTable\Driver\Redis} via
+ *             {@see \Horde\Core\Factory\HashTableFactory}. The PSR-4 driver
+ *             supports phpredis as well as Predis and uses plain prefix+key
+ *             storage instead of MD5 hashing.
  */
 class Horde_HashTable_Predis extends Horde_HashTable_Base implements Horde_HashTable_Lock
 {

--- a/lib/Horde/HashTable/Vfs.php
+++ b/lib/Horde/HashTable/Vfs.php
@@ -29,6 +29,13 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   HashTable
  * @since     1.2.0
+ *
+ * @deprecated The legacy Horde_HashTable_Base interface is deprecated. The
+ *             VFS-backed file storage pattern has no PSR-4 equivalent in the
+ *             new Horde\HashTable\Driver namespace; consumers needing
+ *             session-scoped temp storage should look at
+ *             Horde_Core_HashTable_Vfs / Horde_Core_HashTable_PersistentSession
+ *             which intentionally remain on the legacy interface.
  */
 class Horde_HashTable_Vfs extends Horde_HashTable_Base
 {


### PR DESCRIPTION
Marks the legacy `Horde_HashTable_*` classes (`Base`, `Lock`, `Predis`, `Memcache`, `Memory`, `Null`, `Vfs`) as `@deprecated` with pointers to their PSR-4 replacements in `Horde\HashTable\Driver\*`. The legacy classes themselves stay for third-party BC.

`Vfs` has no PSR-4 equivalent; the deprecation notice records that the file-backed pattern is intentionally retained for `Horde_Core_HashTable_Vfs` / `PersistentSession`.

Refs https://github.com/horde/Core/issues/131