### PR TITLE
fix(serialization): accept non-string stored values in deserializeValue

### DIFF
--- a/src/SerializationTrait.php
+++ b/src/SerializationTrait.php
@@ -50,12 +50,21 @@ trait SerializationTrait
     /**
      * Deserialize a value retrieved from a string-only backend.
      *
-     * @param string $stored  The raw stored string.
+     * Accepts mixed so co-tenant writers (legacy Horde_HashTable_Memcache,
+     * prior releases of this package, or unrelated components sharing the
+     * same memcached pool) that stored bare non-string scalars are passed
+     * through instead of tripping a strict-type error. String values still
+     * go through the s:/p: prefix protocol; anything else is returned as-is.
+     *
+     * @param mixed $stored  The raw stored value as returned by the backend.
      *
      * @return mixed  The original value.
      */
-    protected function deserializeValue(string $stored): mixed
+    protected function deserializeValue(mixed $stored): mixed
     {
+        if (!is_string($stored)) {
+            return $stored;
+        }
         if (str_starts_with($stored, 's:')) {
             return substr($stored, 2);
         }

--- a/test/src/Unit/SerializationTraitTest.php
+++ b/test/src/Unit/SerializationTraitTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\HashTable\Test\Src\Unit;
+
+use Horde\HashTable\SerializationTrait;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exposes the protected trait methods so tests can hit them directly.
+ */
+final class SerializationTraitConsumer
+{
+    use SerializationTrait;
+
+    public function encode(mixed $value): string
+    {
+        return $this->serializeValue($value);
+    }
+
+    public function decode(mixed $stored): mixed
+    {
+        return $this->deserializeValue($stored);
+    }
+}
+
+#[CoversTrait(SerializationTrait::class)]
+final class SerializationTraitTest extends TestCase
+{
+    private SerializationTraitConsumer $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new SerializationTraitConsumer();
+    }
+
+    #[Test]
+    public function stringRoundTrip(): void
+    {
+        $this->assertSame('hello', $this->sut->decode($this->sut->encode('hello')));
+    }
+
+    #[Test]
+    public function intRoundTrip(): void
+    {
+        $this->assertSame(42, $this->sut->decode($this->sut->encode(42)));
+    }
+
+    #[Test]
+    public function arrayRoundTrip(): void
+    {
+        $value = ['a' => 1, 'b' => [2, 3]];
+        $this->assertSame($value, $this->sut->decode($this->sut->encode($value)));
+    }
+
+    /**
+     * Values retrieved from the backend that never went through the trait's
+     * writer (co-tenant writer, legacy driver, prior release) must pass
+     * through instead of tripping a strict-type error.
+     */
+    #[Test]
+    public function nonStringInputPassesThroughUnchanged(): void
+    {
+        $this->assertSame(1735689600, $this->sut->decode(1735689600));
+        $this->assertSame(true, $this->sut->decode(true));
+        $this->assertSame(null, $this->sut->decode(null));
+        $this->assertSame(['x' => 1], $this->sut->decode(['x' => 1]));
+    }
+
+    /**
+     * Bare (unprefixed) strings — the "legacy data" case documented in the
+     * trait — must round-trip as a raw string.
+     */
+    #[Test]
+    public function unprefixedStringTreatedAsRaw(): void
+    {
+        $this->assertSame('legacy', $this->sut->decode('legacy'));
+    }
+
+    #[Test]
+    public function stringPrefixShortForm(): void
+    {
+        // Bytes that happen to look like the p: prefix don't get confused
+        // with prefixed content when they came from the s: writer.
+        $encoded = $this->sut->encode('p:not-really-serialized');
+        $this->assertSame('p:not-really-serialized', $this->sut->decode($encoded));
+    }
+}


### PR DESCRIPTION
## Summary

Reported on the horde mailing list: with Memcache configured, IMP dynamic view crashes on the ThemesCache read path:

\`\`\`
TypeError: Horde\HashTable\Driver\Memcache::deserializeValue(): Argument #1 (\$stored) must be of type string, int given, called in .../Driver/Memcache.php on line 99
  and defined in .../SerializationTrait.php:57
\`\`\`

## Root cause

\`HashTable\Driver\Memcache::getMultiple()\` calls \`\$this->deserializeValue(\$val)\` on every hit, where \`\$val\` is what \`MemcacheApi::getItems()\` returns after its own \`unserialize()\` pass (see \`MemcacheApi.php:583\`).

The value in that slot is not always a string. Any of the following puts a non-prefixed value into the same memcached pool:

- The legacy \`Horde_HashTable_Memcache\` driver (still in \`lib/\`) writes raw values with no \`s:\`/\`p:\` prefix.
- The legacy \`Horde_Cache_Storage_Hashtable::set()\` branch (\`lib/Horde/Cache/Storage/Hashtable.php:128\`) stores \`time()\` as an int for the timestamp slot.
- Prior releases of this package running against the same pool before the upgrade.
- Any co-tenant component using \`MemcacheApi\` directly.

\`SerializationTrait\` already documents the intent to be forgiving (\"Legacy data without prefix — treat as raw string\", line 65–66), but the \`string \$stored\` type declaration prevents that branch from ever running for non-strings and throws a TypeError instead.

## Change

\`SerializationTrait::deserializeValue()\` now takes \`mixed\` and passes non-strings through unchanged. String values still go through the \`s:\`/\`p:\` prefix protocol; unprefixed strings still fall through to the documented raw-string path.

New unit tests in \`test/src/Unit/SerializationTraitTest.php\` cover:

- string / int / array round trips through \`serialize\`+\`deserialize\`
- non-string inputs (int, bool, null, array) pass through
- unprefixed strings return as raw
- \`s:\`-prefixed strings whose payload happens to start with \`p:\` are not misclassified

Fixes the mailing-list crash without changing behaviour for values written by the modern writer.